### PR TITLE
Using newer loki api

### DIFF
--- a/Loki/LokiContentStream.cs
+++ b/Loki/LokiContentStream.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -12,36 +13,22 @@ namespace log4net.Appender.Loki
 
     internal class LokiContentStream
     {
-        [JsonIgnore]
-        public List<LokiLabel> Labels { get; } = new List<LokiLabel>();
+        [JsonProperty("stream")]
+        public Dictionary<string, string> Labels { get; set; } = new Dictionary<string, string>();
 
-        [JsonProperty("labels")]
-        public string LabelsString
+        [JsonIgnore]
+        public List<LokiEntry> Entries { get; set; } = new List<LokiEntry>();
+
+        [JsonProperty("values")]
+        public IEnumerable<List<string>> Values
         {
             get
             {
-                StringBuilder sb = new StringBuilder("{");
-                bool firstLabel = true;
-                foreach (LokiLabel label in Labels)
+                for (int i = 0; i < Entries.Count; i++)
                 {
-                    if (firstLabel)
-                        firstLabel = false;
-                    else
-                        sb.Append(",");
-
-                    sb.Append(label.Key);
-                    sb.Append("=\"");
-                    sb.Append(label.Value);
-                    sb.Append("\"");
+                    yield return Entries[i].ToStringList();
                 }
-
-                sb.Append("}");
-                return sb.ToString();
             }
         }
-
-
-        [JsonProperty("entries")]
-        public List<LokiEntry> Entries { get; set; } = new List<LokiEntry>();
     }
 }

--- a/Loki/LokiEntry.cs
+++ b/Loki/LokiEntry.cs
@@ -8,16 +8,25 @@ namespace log4net.Appender.Loki
 {
     internal class LokiEntry
     {
-        public LokiEntry(string ts, string line)
+        public LokiEntry(DateTime timestamp, string line)
         {
-            Ts = ts;
+            Timestamp = timestamp;
             Line = line;
         }
 
-        [JsonProperty("ts")]
-        public string Ts { get; set; }
+        public DateTime Timestamp { get; set; }
 
-        [JsonProperty("line")]
         public string Line { get; set; }
+
+        private long UnixTimeInNanoseconds(DateTime fromDate)
+        {
+            DateTime epochStart = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+            return (fromDate - epochStart).Ticks * 100;
+        }
+
+        public List<string> ToStringList()
+        {
+            return new List<string>() { UnixTimeInNanoseconds(Timestamp).ToString(), Line };
+        }
     }
 }

--- a/Loki/LokiRouteBuilder.cs
+++ b/Loki/LokiRouteBuilder.cs
@@ -12,6 +12,6 @@ namespace log4net.Appender.Loki
             return host.Substring(host.Length - 1) != "/" ? $"{host}{PostDataUri}" : $"{host.TrimEnd('/')}{PostDataUri}";
         }
 
-        public const string PostDataUri = "/api/prom/push";
+        public const string PostDataUri = "/loki/api/v1/push";
     }
 }


### PR DESCRIPTION
Documentation of Loki says
WARNING: /api/prom/push is DEPRECATED; use /loki/api/v1/push instead.

Because I am new to Loki I decided to implement the new api so I do not start with something depricated..